### PR TITLE
Refactor postcondition for class initialization

### DIFF
--- a/src/readonce.py
+++ b/src/readonce.py
@@ -43,7 +43,7 @@ class ReadOnce(metaclass=Final):
     __secrets: List[str] = []
     __is_consumed: bool = False
 
-    @icontract.ensure(lambda self: not self.__secrets and not self.__is_consumed)
+    @icontract.ensure(lambda self: self.__is_reset())
     def __init__(self) -> None:
         self.__reset_secrets()
         self.__reset_is_consumed()
@@ -59,6 +59,10 @@ class ReadOnce(metaclass=Final):
     @classmethod
     def __update_is_consumed(cls):
         cls.__is_consumed = True
+
+    @classmethod
+    def __is_reset(cls):
+        return len(cls.__secrets) == 0 and cls.__is_consumed is False
 
     def add_secret(self, *args):
         if self.__is_consumed:

--- a/src/readonce.py
+++ b/src/readonce.py
@@ -62,7 +62,7 @@ class ReadOnce(metaclass=Final):
 
     @classmethod
     def __is_reset(cls):
-        return len(cls.__secrets) == 0 and cls.__is_consumed is False
+        return not cls.secrets and not cls.__is_consumed
 
     def add_secret(self, *args):
         if self.__is_consumed:


### PR DESCRIPTION
In order to have a clear postcondition, I added a new class method (`__is_reset`) which performs the same checks as before.

I updated `not` statements as well, in order to have more readable code.